### PR TITLE
Update for Arma 2.14

### DIFF
--- a/cvo_compats_common/cba/config.cpp
+++ b/cvo_compats_common/cba/config.cpp
@@ -1,6 +1,4 @@
-#include "\cvo\compats\cvo_compats_common\macros.hpp"
 
-#if CBA_LOADED
 class CfgPatches {
 	class CVO_Compats_Common_CBA {
 		addonRootClass = "CVO_Compats_Common";
@@ -9,6 +7,7 @@ class CfgPatches {
 			"cba_main"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};
@@ -65,5 +64,3 @@ class CfgWeapons {
 		isIR = 0;
 	};
 };
-
-#endif

--- a/cvo_compats_common/config.cpp
+++ b/cvo_compats_common/config.cpp
@@ -1,4 +1,3 @@
-#include "macros.hpp"
 
 class CfgPatches {
 	class CVO_Compats_Common {

--- a/cvo_compats_common/greenmag/config.cpp
+++ b/cvo_compats_common/greenmag/config.cpp
@@ -1,6 +1,5 @@
 #include "macros_greenmag.hpp"
 
-#if GREENMAG_LOADED
 class CfgPatches {
 	class CVO_Compats_Common_GreenMag {
 		addonRootClass = "CVO_Compats_Common";
@@ -9,6 +8,7 @@ class CfgPatches {
 			"greenmag_main"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {
@@ -487,4 +487,3 @@ class CfgWeapons {
 	#include "belts\792x57_Tracer.hpp"
 	
 };
-#endif

--- a/cvo_compats_rhsafrf/cba/CfgWeapons.hpp
+++ b/cvo_compats_rhsafrf/cba/CfgWeapons.hpp
@@ -120,7 +120,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -166,7 +166,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -255,7 +255,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -301,7 +301,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -388,7 +388,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -434,7 +434,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -520,7 +520,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -562,7 +562,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -638,7 +638,7 @@ class CfgWeapons {
 					start=0;
 					constant=2;
 					linear=1;
-					quadratic=75;
+					quadratic=1;
 				};
 				scale[]={0};
 			};
@@ -699,7 +699,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -744,7 +744,7 @@ class CfgWeapons {
 					start = 0.1;
 					constant = 2;
 					linear = 2;
-					quadratic = 25;
+					quadratic = 1;
 
 					hardLimitStart = 100;
 					hardLimitEnd = 200;
@@ -826,7 +826,7 @@ class CfgWeapons {
 					start=0;
 					constant=2;
 					linear=1;
-					quadratic=75;
+					quadratic=1;
 				};
 				scale[]={0};
 			};

--- a/cvo_compats_rhsafrf/cba/config.cpp
+++ b/cvo_compats_rhsafrf/cba/config.cpp
@@ -1,7 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\macros.hpp"
-
-#if RHS_AFRF_LOADED
-#if CBA_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSAFRF_CBA {
@@ -13,6 +9,7 @@ class CfgPatches {
 			"CVO_Compats_Common"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};
@@ -24,7 +21,3 @@ class CfgPatches {
 #include "CfgEventHandlers.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"
-
-
-#endif
-#endif

--- a/cvo_compats_rhsafrf/config.cpp
+++ b/cvo_compats_rhsafrf/config.cpp
@@ -1,6 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\macros.hpp"
-
-#if RHS_AFRF_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSAFRF {
@@ -8,12 +5,14 @@ class CfgPatches {
 		name = "CVO Compatibilities - RHS AFRF";
 		url = "https://github.com/SkippieDippie/CVO-Everything-Compats";
 
-		requiredAddons[] = {"CVO_Compats_Common"};
+		requiredAddons[] = {
+			"rhsafrf_main",
+			"CVO_Compats_Common"
+		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};
 	};
 };
-
-#endif

--- a/cvo_compats_rhsafrf/greenmag/config.cpp
+++ b/cvo_compats_rhsafrf/greenmag/config.cpp
@@ -1,7 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\greenmag\macros_greenmag.hpp"
-
-#if RHS_AFRF_LOADED
-#if GREENMAG_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSAFRF_GreenMag {
@@ -12,6 +8,7 @@ class CfgPatches {
 			"greenmag_main"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};
@@ -32,6 +29,3 @@ class CfgMagazines {
 	#include "magazines\rhs_afrf_338.hpp"
 
 };
-
-#endif
-#endif

--- a/cvo_compats_rhsgref/config.cpp
+++ b/cvo_compats_rhsgref/config.cpp
@@ -8,8 +8,12 @@ class CfgPatches {
 		name = "CVO Compatibilities - RHS GREF";
 		url = "https://github.com/SkippieDippie/CVO-Everything-Compats";
 
-		requiredAddons[] = {"CVO_Compats_Common"};
+		requiredAddons[] = {
+			"rhsgref_main",
+			"CVO_Compats_Common"
+		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};

--- a/cvo_compats_rhsgref/greenmag/config.cpp
+++ b/cvo_compats_rhsgref/greenmag/config.cpp
@@ -1,7 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\greenmag\macros_greenmag.hpp"
-
-#if RHS_GREF_LOADED
-#if GREENMAG_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSGREF_GreenMag {
@@ -12,6 +8,7 @@ class CfgPatches {
 			"greenmag_main"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};
@@ -33,6 +30,3 @@ class CfgMagazines {
 	#include "magazines\rhs_gref_792x33.hpp"
 	#include "magazines\rhs_gref_8x22.hpp"
 };
-
-#endif
-#endif

--- a/cvo_compats_rhssaf/config.cpp
+++ b/cvo_compats_rhssaf/config.cpp
@@ -1,6 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\macros.hpp"
-
-#if RHS_SAF_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSSAF {
@@ -8,12 +5,14 @@ class CfgPatches {
 		name = "CVO Compatibilities - RHS SAF";
 		url = "https://github.com/SkippieDippie/CVO-Everything-Compats";
 
-		requiredAddons[] = {"CVO_Compats_Common"};
+		requiredAddons[] = {
+			"rhssaf_main",
+			"CVO_Compats_Common"
+		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};
 	};
 };
-
-#endif

--- a/cvo_compats_rhssaf/greenmag/config.cpp
+++ b/cvo_compats_rhssaf/greenmag/config.cpp
@@ -1,7 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\greenmag\macros_greenmag.hpp"
-
-#if RHS_SAF_LOADED
-#if GREENMAG_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSSAF_GreenMag {
@@ -12,6 +8,7 @@ class CfgPatches {
 			"greenmag_main"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
 
 		units[] = {};
 		weapons[] = {};
@@ -30,6 +27,3 @@ class CfgMagazines {
 	#include "magazines\rhs_saf_9x19.hpp"
 	
 };
-
-#endif
-#endif

--- a/cvo_compats_rhsusaf/config.cpp
+++ b/cvo_compats_rhsusaf/config.cpp
@@ -1,6 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\macros.hpp"
-
-#if RHS_USAF_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSUSAF {
@@ -8,12 +5,15 @@ class CfgPatches {
 		name = "CVO Compatibilities - RHS USAF";
 		url = "https://github.com/SkippieDippie/CVO-Everything-Compats";
 
-		requiredAddons[] = {"CVO_Compats_Common"};
+		requiredAddons[] = {
+			"rhsusf_main",
+			"CVO_Compats_Common"
+		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
+
 
 		units[] = {};
 		weapons[] = {};
 	};
 };
-
-#endif

--- a/cvo_compats_rhsusaf/greenmag/config.cpp
+++ b/cvo_compats_rhsusaf/greenmag/config.cpp
@@ -1,7 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\greenmag\macros_greenmag.hpp"
-
-#if RHS_USAF_LOADED
-#if GREENMAG_LOADED
 
 class CfgPatches {
 	class CVO_Compats_RHSUSAF_GreenMag {
@@ -12,6 +8,8 @@ class CfgPatches {
 			"greenmag_main"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
+
 
 		units[] = {};
 		weapons[] = {};
@@ -30,6 +28,3 @@ class CfgMagazines {
 	#include "magazines\rhs_usaf_9x19.hpp"
 	
 };
-
-#endif
-#endif

--- a/cvo_compats_uk3cb_factions/config.cpp
+++ b/cvo_compats_uk3cb_factions/config.cpp
@@ -1,6 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\macros.hpp"
-
-#if UK3CB_FACTIONS_LOADED
 
 class CfgPatches {
 	class CVO_Compats_UK3CB_Factions {
@@ -8,12 +5,15 @@ class CfgPatches {
 		name = "CVO Compatibilities - UK3CB Factions";
 		url = "https://github.com/SkippieDippie/CVO-Everything-Compats";
 
-		requiredAddons[] = {"CVO_Compats_Common"};
+		requiredAddons[] = {
+			"uk3cb_factions_common",
+			"CVO_Compats_Common"
+		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
+
 
 		units[] = {};
 		weapons[] = {};
 	};
 };
-
-#endif

--- a/cvo_compats_uk3cb_factions/greenmag/config.cpp
+++ b/cvo_compats_uk3cb_factions/greenmag/config.cpp
@@ -1,7 +1,3 @@
-#include "\cvo\compats\cvo_compats_common\greenmag\macros_greenmag.hpp"
-
-#if UK3CB_FACTIONS_LOADED
-#if GREENMAG_LOADED
 
 class CfgPatches {
 	class CVO_Compats_UK3CB_Factions_GreenMag {
@@ -12,6 +8,8 @@ class CfgPatches {
 			"greenmag_main"
 		};
 		requiredVersion = 1.00;
+		skipWhenMissingDependencies = 1;
+		
 
 		units[] = {};
 		weapons[] = {};
@@ -52,6 +50,3 @@ class CfgMagazines {
 	#include "magazines\uk3cb_factions_9x19.hpp"
 
 };
-
-#endif
-#endif


### PR DESCRIPTION
### Changes in this PR:
#### Common:
* changed: the config now uses the new skipWhenDependenciesMissing parameter instead of __has_include command;
* changed: "reverted" back the light attenuation quadratic parameter;
